### PR TITLE
Use the user provided channel if possible as a default channel

### DIFF
--- a/app.py
+++ b/app.py
@@ -320,6 +320,8 @@ with st.sidebar:
         "Select a channel:",
         CHANNELS,
         key="channel",
+        # Use the user provided channel (via query params) if possible.
+        index=url_ok and CHANNELS.index(url_params["channel"]) or 0,
     )
     package_name = st.selectbox(
         "Enter a package name:",

--- a/app.py
+++ b/app.py
@@ -321,7 +321,7 @@ with st.sidebar:
         CHANNELS,
         key="channel",
         # Use the user provided channel (via query params) if possible.
-        index=url_ok and CHANNELS.index(url_params["channel"]) or 0,
+        index=url_params["channel"] in CHANNELS and CHANNELS.index(url_params["channel"]) or 0,
     )
     package_name = st.selectbox(
         "Enter a package name:",

--- a/app.py
+++ b/app.py
@@ -321,7 +321,7 @@ with st.sidebar:
         CHANNELS,
         key="channel",
         # Use the user provided channel (via query params) if possible.
-        index=url_params["channel"] in CHANNELS and CHANNELS.index(url_params["channel"]) or 0,
+        index=CHANNELS.index(url_params["channel"]) if url_params["channel"] in CHANNELS else 0,
     )
     package_name = st.selectbox(
         "Enter a package name:",


### PR DESCRIPTION
Fixes #5

This PR fixes the problem where going directly to https://conda-metadata-app.streamlit.app/?q=pkgs%2Fmain would redirect to https://conda-metadata-app.streamlit.app/?q=conda-forge.