### PR TITLE
fix: use local channel_name variable instead of global channel

### DIFF
--- a/conda_metadata_app/pages/main_page.py
+++ b/conda_metadata_app/pages/main_page.py
@@ -191,7 +191,7 @@ def get_all_packages_sections_from_repodata(
             sections.update(repodata[key])
 
     if with_broken:
-        for removed_artifact in get_repodata(channel, arch_subdir).get("removed", []):
+        for removed_artifact in get_repodata(channel_name, arch_subdir).get("removed", []):
             removed_artifact: str
 
             if removed_artifact.endswith(".tar.bz2"):


### PR DESCRIPTION
This issue prevented URLs copied from the address bar from working. We can avoid this in the future if we use the global context as little as possible, even though that's not idiomatic for Streamlit.

Cc @pavelzw