### PR TITLE
fix: get version info in Docker image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout branch
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          fetch-depth: 0
 
       - name: Login into GHCR
         if: github.ref_name == 'main'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -46,6 +46,7 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
+          context: .
           push: ${{ github.ref_name == 'main' }}
           file: Dockerfile
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM ubuntu:24.04 AS production
 COPY --from=build /app/.pixi/envs/default /app/.pixi/envs/default
 COPY --from=build /app/app.py /app
 COPY --from=build /app/app_config.toml /app
+COPY --from=build /app/version_info.json /app
 COPY --from=build --chmod=0555 /entrypoint.sh /
 
 WORKDIR /app

--- a/conda_metadata_app/app_config.py
+++ b/conda_metadata_app/app_config.py
@@ -7,7 +7,6 @@ import json
 import os
 from collections.abc import Iterable
 from enum import StrEnum
-from subprocess import CalledProcessError, check_output
 from typing import Literal, Self
 
 from pydantic import (
@@ -426,23 +425,6 @@ def export_json_schema() -> None:
     with open("app_config.schema.json", "w") as f:
         json.dump(AppConfig.model_json_schema(), f, indent=2)
         f.write("\n")
-
-
-def app_version() -> str:
-    try:
-        return check_output(
-            [
-                "git",
-                "--no-pager",
-                "log",
-                "-1",
-                "--pretty=format:`%h (%cd)`",
-                "--date=format:%Y-%m-%d %H:%M:%S",
-            ],
-            text=True,
-        ).strip()
-    except CalledProcessError:
-        return ""
 
 
 if __name__ == "__main__":

--- a/conda_metadata_app/pages/main_page.py
+++ b/conda_metadata_app/pages/main_page.py
@@ -71,7 +71,7 @@ st.set_page_config(
     initial_sidebar_state="expanded",
     menu_items={
         "about": f"""
-        **📦 conda-metadata-app `{get_version_info()}`**
+        **📦 conda-metadata-app `{get_version_info() or "(Version N/A)"}`**
 
         Browse metadata from conda packages in conda-forge, bioconda and others.
         """

--- a/conda_metadata_app/pages/main_page.py
+++ b/conda_metadata_app/pages/main_page.py
@@ -34,8 +34,8 @@ from conda_metadata_app.app_config import (
     MetadataRetrieval,
     PackageDiscoveryChoice,
     Secret,
-    app_version,
 )
+from conda_metadata_app.version_info import get_version_info
 from conda_metadata_app.version_order import VersionOrder
 
 if not os.environ.get("CACHE_DIR"):
@@ -71,7 +71,7 @@ st.set_page_config(
     initial_sidebar_state="expanded",
     menu_items={
         "about": f"""
-        **📦 conda-metadata-app `{app_version()}`**
+        **📦 conda-metadata-app `{get_version_info()}`**
 
         Browse metadata from conda packages in conda-forge, bioconda and others.
         """

--- a/conda_metadata_app/version_info.py
+++ b/conda_metadata_app/version_info.py
@@ -1,0 +1,83 @@
+"""
+This module provides a way to retrieve version information about conda-metadata-app.
+"""
+
+import datetime
+import subprocess
+
+from pydantic import BaseModel, Field
+
+VERSION_INFO_FILE = "version_info.json"
+
+
+class VersionInfo(BaseModel):
+    git_hash: str = Field(pattern=r"^[0-9a-f]{40}$")
+    timestamp: datetime.datetime
+
+    @property
+    def short_git_hash(self):
+        return self.git_hash[:7]
+
+    def timestamp_string(self):
+        return self.timestamp.strftime("%Y-%m-%d %H:%M:%S")
+
+    def __str__(self):
+        return f"{self.short_git_hash} ({self.timestamp_string()})"
+
+
+def get_version_info_from_git() -> VersionInfo:
+    """
+    Returns version information from the `.git` directory.
+    This requires you to have the `git` command line tool installed.
+
+    You should only use this function from a Streamlit Cloud deployment or
+    during the Docker build process, as neither git nor the `.git` directory
+    will be available in the final Docker image!
+    """
+    git_info = subprocess.check_output(
+        [
+            "git",
+            "--no-pager",
+            "log",
+            "-1",
+            "--pretty=format:%H-%cd",
+            "--date=unix",
+        ],
+        text=True,
+    ).strip()
+
+    git_hash, timestamp = git_info.split("-")
+
+    return VersionInfo(
+        git_hash=git_hash,
+        timestamp=datetime.datetime.fromtimestamp(int(timestamp), datetime.UTC),
+    )
+
+
+def save_version_info_from_git() -> None:
+    """
+    Saves the version information from git to version_info.json.
+    See the `get_version_info_from_git` function for more information.
+    """
+    version_info = get_version_info_from_git()
+
+    with open(VERSION_INFO_FILE, "w") as f:
+        f.write(version_info.model_dump_json(indent=2))
+
+
+def get_version_info() -> VersionInfo:
+    """
+    Get the version information of the current app installation.
+    This works as follows:
+    1. Retrieve the version information from the `version_info.json` file (relevant for Docker image).
+    2. If the file does not exist, retrieve the version information from git (relevant for Streamlit Cloud).
+    """
+    try:
+        with open(VERSION_INFO_FILE) as f:
+            return VersionInfo.model_validate_json(f.read())
+    except FileNotFoundError:
+        return get_version_info_from_git()
+
+
+if __name__ == "__main__":
+    save_version_info_from_git()

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -8,3 +8,5 @@ pixi run -e default postinstall-production
 echo "#!/bin/sh" > /entrypoint.sh
 pixi shell-hook -e default -s bash >> /entrypoint.sh
 echo 'exec "$@"' >> /entrypoint.sh
+
+pixi run -e default save-version-info

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,7 @@ platforms = ["linux-64", "win-64", "osx-arm64", "osx-64", "linux-aarch64"]
 dev = "python -m streamlit run --server.runOnSave=true app.py"
 deploy = "python -m streamlit run --server.headless=true --global.developmentMode=false app.py"
 schema = "python -m conda_metadata_app.app_config"
+save-version-info = "python -m conda_metadata_app.version_info"
 postinstall-production = "pip install --no-deps --disable-pip-version-check dist/conda_metadata_app-*.whl"
 
 


### PR DESCRIPTION
179cd5e6a275a3f92080cf1059ebfb9bb0c0674f introduced a bug into the Docker deployment because it neither has git installed nor the `.git` directory is present in the image.

![image](https://github.com/user-attachments/assets/195b7b06-55dc-48b8-8876-cc82fccf72a8)

This PR fixes this issue by introducing a file `version_info.json` that contains version information. The file is copied into the Docker image. Else, the version information is fetched from git (as it is currently).

@jaimergp

Cc @pavelzw