### PR TITLE
get run_exports from v1 recipes

### DIFF
--- a/conda_metadata_app/pages/main_page.py
+++ b/conda_metadata_app/pages/main_page.py
@@ -1141,14 +1141,12 @@ if isinstance(data, dict):
         )
         download = f"[artifact download]({_download_url})"
     maintainers = []
-    if recipe := data.get("rendered_recipe", {}).get("recipe"):  # recipe.yaml
+    rendered_recipe = data.get("rendered_recipe", {})
+    if recipe := rendered_recipe.get("recipe"):  # recipe.yaml
         recipe_format = f"recipe.yaml v{recipe.get('schema_version', 1)}"
-        rattler_build_version = (
-            data.get("rendered_recipe").get("system_tools").get("rattler-build", "")
-        )
+        rattler_build_version = rendered_recipe.get("system_tools").get("rattler-build", "")
         built_with = f"`rattler-build {rattler_build_version}`"
     else:
-        rendered_recipe = data["rendered_recipe"]
         recipe_format = "meta.yaml"
         conda_build_version = data.get("about", {}).get("conda_build_version", "")
         conda_version = data.get("about", {}).get("conda_version", "")
@@ -1157,9 +1155,7 @@ if isinstance(data, dict):
             built_with = f"`conda-build {conda_build_version}`"
         if conda_version:
             built_with += f", `conda {conda_version}`"
-    extra = data.get("rendered_recipe", {}).get("extra", {}) or data.get(
-        "rendered_recipe", {}
-    ).get("recipe", {}).get("extra", {})
+    extra = rendered_recipe.get("extra", {}) or recipe.get("extra", {})
     for user in extra.get("recipe-maintainers", ["*N/A*"]):
         if user == "*N/A*":
             maintainers.append(user)
@@ -1197,7 +1193,14 @@ if isinstance(data, dict):
     st.markdown(" ")
     dependencies = data.get("index", {}).get("depends", ())
     constraints = data.get("index", {}).get("constrains", ())
-    run_exports = data.get("rendered_recipe", {}).get("build", {}).get("run_exports", ())
+    if recipe:
+        # v1
+        run_exports = (
+            rendered_recipe.get("finalized_dependencies", {}).get("run", {}).get("run_exports", {})
+        )
+    else:
+        # v0
+        run_exports = rendered_recipe.get("build", {}).get("run_exports", {})
     if dependencies or constraints or run_exports:
         c1, c2 = st.columns([1, 1])
         for title, key, specs, col in [
@@ -1260,9 +1263,7 @@ elif data == "show_latest":
         platforms = platforms[1:-1]
         published = item.find("pubDate").text
         more_url = f"/?q={channel}/{name}"
-        table.append(
-            f"| {n} | [{name}]({more_url}) | {version} | {platforms} | {published}"
-        )
+        table.append(f"| {n} | [{name}]({more_url}) | {version} | {platforms} | {published}")
     st.markdown(
         f"## Latest {n} updates in [{channel}](https://anaconda.org/{channel.split('/', 1)[-1]})"
     )


### PR DESCRIPTION
Located at `rendered_recipe.finalized_dependencies.run.run_exports`

Sample package at https://conda-metadata-app.streamlit.app/?q=conda-forge%2Flinux-64%2Ffenics-libdolfinx-0.9.0-hb85e8c2_108.conda missing run_exports and looks like this after this PR:


<img width="780" alt="Screenshot 2025-03-04 at 11 45 14" src="https://github.com/user-attachments/assets/a64be55c-29a8-42fc-8d31-586eebf70bf6" />
