### PR TITLE
ci: Add pixi update script + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      gh-actions:
+        patterns:
+          - "*"

--- a/.github/scripts/sync-deps.sh
+++ b/.github/scripts/sync-deps.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Bash Script to sync explicit dependencies from pixi.lock into requirements.txt
+set -euo pipefail
+
+echo "# please sync the dependencies with pyproject.toml and pixi.toml" > requirements.txt
+pixi list --explicit --json | yq -r '.[] | select(.name != "python") | "\(.name)==\(.version)"' >> requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,23 @@ jobs:
             echo "::error::The schema is out of date. Please run 'pixi run schema' and commit the changes."
             exit 1
           fi
+
+  check-requirements-txt:
+    name: Check requirements.txt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@fef5c9568ca6c4ff7707bf840ab0692ba3f08293 # v0.9.0
+        with:
+          run-install: false
+      - name: Sync to requirements.txt
+        run: ./.github/scripts/sync-deps.sh
+      - name: Check for changes
+        run: |
+          git diff --exit-code
+          if [ $? -eq 1 ]
+          then
+            echo "::error::The requirements.txt is out of date. Please run './.github/scripts/sync-deps.sh' and commit the changes."
+            exit 1
+          fi

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -1,0 +1,41 @@
+name: Update lockfiles
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 7 5 1 * * # each 1st at 05:07 UTC
+
+jobs:
+  pixi-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@fef5c9568ca6c4ff7707bf840ab0692ba3f08293 # v0.9.0
+        with:
+          run-install: false
+      - name: Update lockfile
+        run: |
+          pixi update --json --no-install --exclude python | pixi exec pixi-diff-to-markdown >> diff.md
+      - name: Sync to requirements.txt
+        run: ./.github/scripts/sync-deps.sh
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update dependencies
+          title: Update dependencies
+          body-path: diff.md
+          branch: update-pixi
+          base: main
+          labels: |
+            pixi
+            dependencies
+          delete-branch: true
+          add-paths: |
+            pixi.toml
+            pixi.lock
+            requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 # please sync the dependencies with pyproject.toml and pixi.toml
-pydantic-settings==2.10.1
-pydantic==2.11.9
-typing-extensions==4.15.0
-zstandard==0.23.0
-py-rattler==0.7.2
 conda-forge-metadata==0.11.0
-conda-package-streaming==0.12.0
 conda-oci-mirror==0.2.3
+conda-package-streaming==0.12.0
+pip==25.2
+py-rattler==0.7.2
+pydantic==2.11.9
+pydantic-settings==2.10.1
 streamlit==1.49.1
 streamlit-searchbox==0.1.20
+typing-extensions==4.15.0
+zstandard==0.23.0


### PR DESCRIPTION
This PR adds three things:

- Dependabot for GitHub Actions
- A custom job running `pixi update` and syncing the resulting locks to `requirements.txt`
- A CI check validating that `requirements.txt` is the output of this other job (for manual changes)

I decided to not implement `pixi upgrade` for now, since proper constraints in `pixi.toml` should lead to our dependencies being up to date most of the time with this approach.

Closes #33.